### PR TITLE
Fix package name on deploy_adhoc_plan and minor typo in deploy_managed_ui

### DIFF
--- a/modules/deploy_adhoc_plan/deploy_adhoc_plan.info
+++ b/modules/deploy_adhoc_plan/deploy_adhoc_plan.info
@@ -1,8 +1,7 @@
 name = Ad Hoc Deployment Plans
 description = Create ad hoc deployment plans associated with user sessions.
+package = Deployment
 core = 7.x
-package = Deploy
-project = deploy_adhoc_plan
 
 configure = admin/config/content/deploy-adhoc-plan
 

--- a/modules/deploy_managed_ui/deploy_managed_ui.module
+++ b/modules/deploy_managed_ui/deploy_managed_ui.module
@@ -73,7 +73,7 @@ function deploy_managed_ui_form_elements(&$form, $submit_handler, $vertical_tabs
   );
 
   $form['deploy_managed_ui']['text'] = array(
-    '#markup' => t('Select the plans to include these chanages in.'),
+    '#markup' => t('Select the plans to include these changes in.'),
   );
 
   $form['deploy_managed_ui']['plans'] = array(


### PR DESCRIPTION
I just noticed that the new Deploy Adhoc module was in its own module grouping because the package name was erroneously named deploy instead of deployment.